### PR TITLE
给动态补充了标题

### DIFF
--- a/starbot/painter/DynamicPicGenerator.py
+++ b/starbot/painter/DynamicPicGenerator.py
@@ -168,10 +168,26 @@ class DynamicPicGenerator:
                 mod: 表情区块字典
             """
             mod["img"] = await open_url_image(mod["emoji"]["icon_url"])
-
-        modules_url = f"https://api.bilibili.com/x/polymer/web-dynamic/v1/detail?timezone_offset=-480&id={dynamic_id}"
-        modules = (await request("GET", modules_url))["item"]["modules"]["module_dynamic"]["desc"]
-        modules = modules["rich_text_nodes"] if modules else []
+        
+        if dynamic_type == 2 or dynamic_type == 4:
+            # 有些动态带有标题，不显示标题会缺少上下文
+            modules_url =("https://api.bilibili.com/x/polymer/web-dynamic/v1/detail?timezone_offset=-480"
+                 f"&platform=web&id={dynamic_id}&features=itemOpusStyle,opusBigCover,onlyfansVote")
+            modules = (await request("GET", modules_url))["item"]["modules"]["module_dynamic"]["major"]["opus"]
+            title = modules["title"]
+            modules = modules["summary"]
+            if modules:
+                modules = modules["rich_text_nodes"]
+                if title is not None:
+                    modules.insert(0,{'orig_text': title+"\n",
+                                       'text': title+"\n",
+                                       'type': 'RICH_TEXT_NODE_TYPE_TEXT'})
+            else:
+                modules = []
+        else :
+            modules_url = f"https://api.bilibili.com/x/polymer/web-dynamic/v1/detail?timezone_offset=-480&id={dynamic_id}"
+            modules = (await request("GET", modules_url))["item"]["modules"]["module_dynamic"]["desc"]
+            modules = modules["rich_text_nodes"] if modules else []
 
         # 下载表情
         download_picture_tasks = []

--- a/starbot/painter/DynamicPicGenerator.py
+++ b/starbot/painter/DynamicPicGenerator.py
@@ -171,17 +171,18 @@ class DynamicPicGenerator:
         
         if dynamic_type == 2 or dynamic_type == 4:
             # 有些动态带有标题，不显示标题会缺少上下文
-            modules_url =("https://api.bilibili.com/x/polymer/web-dynamic/v1/detail?timezone_offset=-480"
-                 f"&platform=web&id={dynamic_id}&features=itemOpusStyle,opusBigCover,onlyfansVote")
+            modules_url =f"https://api.bilibili.com/x/polymer/web-dynamic/v1/detail?timezone_offset=-480&id={dynamic_id}&features=itemOpusStyle,opusBigCover,onlyfansVote"
             modules = (await request("GET", modules_url))["item"]["modules"]["module_dynamic"]["major"]["opus"]
             title = modules["title"]
             modules = modules["summary"]
             if modules:
                 modules = modules["rich_text_nodes"]
                 if title is not None:
-                    modules.insert(0,{'orig_text': title+"\n",
-                                       'text': title+"\n",
-                                       'type': 'RICH_TEXT_NODE_TYPE_TEXT'})
+                    modules.insert(0, {
+                        'orig_text': f"{title}\n",
+                        'text': f"{title}\n",
+                        'type': 'RICH_TEXT_NODE_TYPE_TEXT'
+                    })
             else:
                 modules = []
         else :


### PR DESCRIPTION

动态之前增加了标题功能。在网页端可见但是推送的时候看不见。
因为标题也是动态的一部分，缺少了一部分文本会看不懂。
排查了原因是调用的接口都不提供标题数据，我找了一个接口把标题加上了。

修改效果如下。
改动只影响带图动态和文本动态的图片生成，已测试。

比如这个动态 https://t.bilibili.com/885290319922331669
左为更改前，右为更改后
<img width="459" alt="Screenshot 2024-01-12 at 02 45 06" src="https://github.com/Starlwr/StarBot/assets/2346805/fedfa9b3-e3fa-4728-b42c-7bb07040cc9b">
