### PR TITLE
修复b站动态绘图报错

### DIFF
--- a/starbot/painter/DynamicPicGenerator.py
+++ b/starbot/painter/DynamicPicGenerator.py
@@ -225,7 +225,8 @@ class DynamicPicGenerator:
         elif dynamic_type == 2:
             # 带图动态
             await cls.__draw_content(pic, modules, text_margin, forward)
-            await cls.__draw_picture_area(pic, card["item"]["pictures"], img_margin, forward)
+            if card["item"]["pictures_count"]:
+                await cls.__draw_picture_area(pic, card["item"]["pictures"], img_margin, forward)
         elif dynamic_type == 4:
             # 纯文字动态
             await cls.__draw_content(pic, modules, text_margin, forward)


### PR DESCRIPTION
报错原因：动态类型为带图动态，但是图片数量为0，导致对象为None
报错分析：B站改动api，带表情动态现在类型为带图动态
报错解决：如果pictures_count大于0，才进行__draw_picture_area

