### PR TITLE
修复B站动态绘图报错

### DIFF
--- a/starbot/painter/DynamicPicGenerator.py
+++ b/starbot/painter/DynamicPicGenerator.py
@@ -225,7 +225,8 @@ class DynamicPicGenerator:
         elif dynamic_type == 2:
             # 带图动态
             await cls.__draw_content(pic, modules, text_margin, forward)
-            await cls.__draw_picture_area(pic, card["item"]["pictures"], img_margin, forward)
+            if card["item"]["pictures"]:
+                await cls.__draw_picture_area(pic, card["item"]["pictures"], img_margin, forward)
         elif dynamic_type == 4:
             # 纯文字动态
             await cls.__draw_content(pic, modules, text_margin, forward)


### PR DESCRIPTION
带有B站表情的动态现在type也可能是2，和图片动态type相同，因此需要检查对应的card["item"]["pictures"]的有效性，或者检查card["item"]["pictures_count"]的值大于0