### PR TITLE
修复好友消息发送失败后剩余推送目标不再继续推送的bug

### DIFF
--- a/starbot/core/sender.py
+++ b/starbot/core/sender.py
@@ -155,6 +155,9 @@ class Bot(BaseModel):
                 except RemoteException as ex:
                     logger.exception("消息推送模块异常", ex)
                     continue
+                except UnknownTarget:
+                    logger.error(f"好友[{msg.id}]消息发送失败: 对象位置未知, 不存在或不可及")
+                    return
         else:
             msgs, exception = await self.group_message_filter(msg)
 


### PR DESCRIPTION
bug场景：up的多个推送目标包含Friend类型推送，假如推送顺序为 好友 -> 群聊 这样的顺序，先发送好友消息产生了UnknownTarget异常后，send_message内部未处理该异常，接下来的剩余所有推送均会失效

发生原因：UnknownTarget产生的逻辑通常为好友已被删除，但是现有onebot转overflow的实现下，存在好友正常但是发送消息产生UnknownTarget的问题，因此需要捕获该异常，剩余推送目标的消息推送才能不受影响
